### PR TITLE
Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
-env:
-  - TOX_ENV=py26-trunkdeps
-  - TOX_ENV=py27-trunkdeps
-  - TOX_ENV=pypy-trunkdeps
+python:
+  - 2.6
+  - 2.7
+  - pypy
 install:
   - pip install -e .
-  - pip install tox
-  - pip install coveralls
+  - pip install coverage coveralls
 script:
-  - tox -e $TOX_ENV
+    - coverage run --source=axiom $(which trial) axiom
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
+env:
+  - TOX_ENV=py26-trunkdeps
+  - TOX_ENV=py27-trunkdeps
+  - TOX_ENV=pypy-trunkdeps
 install:
-  - "pip install -e ."
+  - pip install -e .
+  - pip install tox
+  - pip install coveralls
 script:
-  - "trial axiom"
+  - tox -e $TOX_ENV
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+install:
+  - "pip install -e ."
+script:
+  - "trial axiom"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - pip install -e .
   - pip install coverage coveralls
 script:
-    - coverage run --source=axiom $(which trial) axiom
+  - coverage run --source=axiom $(which trial) axiom
 after_success:
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ deps =
 changedir = {toxworkdir}
 commands =
     pip install -r {toxinidir}/requirements-testing.txt
-    coverage run --source=axiom {envdir}/bin/trial {posargs:axiom}
+    coverage run {envdir}/bin/trial \
+        --temp-directory={envdir}/_trial {posargs:axiom}
     coverage report --rcfile={toxinidir}/.coveragerc
     coverage html --rcfile={toxinidir}/.coveragerc --directory {envdir}/_coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ deps =
 changedir = {toxworkdir}
 commands =
     pip install -r {toxinidir}/requirements-testing.txt
-    coverage run --source=axiom {envdir}/bin/trial \
-        --temp-directory={envdir}/_trial {posargs:axiom}
+    coverage run --source=axiom {envdir}/bin/trial {posargs:axiom}
     coverage report --rcfile={toxinidir}/.coveragerc
     coverage html --rcfile={toxinidir}/.coveragerc --directory {envdir}/_coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
 changedir = {toxworkdir}
 commands =
     pip install -r {toxinidir}/requirements-testing.txt
-    coverage run {envdir}/bin/trial \
+    coverage run --source=axiom {envdir}/bin/trial \
         --temp-directory={envdir}/_trial {posargs:axiom}
     coverage report --rcfile={toxinidir}/.coveragerc
     coverage html --rcfile={toxinidir}/.coveragerc --directory {envdir}/_coverage


### PR DESCRIPTION
Added python 2.6, 2.7 and pypy to the list of versions to run Axiom against.
The tests are run with coverage and then submitted to Coveralls if all the tests pass.

Note: I tried to run Tox from Travis but had tests failing inconsistently and ended up dropping support for it.