### PR TITLE
Drop Python 2.6 from CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ python:
   - 2.7
 
 env:
-  - TOX_ENV=py26-twlatest
   - TOX_ENV=py27-twlatest
   - TOX_ENV=pypy-twlatest
-  - TOX_ENV=py26-tw150
   - TOX_ENV=py27-tw150
   - TOX_ENV=pypy-tw150
   - TOX_ENV=py27-twtrunk

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26-{twlatest,tw150},{py26,py27,pypy}-{twtrunk,twlatest,tw150}
+envlist = {py27,pypy}-{twtrunk,twlatest,tw150}
 
 [testenv]
 deps =


### PR DESCRIPTION
Twisted has dropped Python 2.6 support, so we might as well follow suit.

This PR doesn't do anything except drop 2.6 from the CI configuration, but I guess it also serves as a policy decision to allow 2.6-incompatible changes in the future, although I don't specifically have any such changes planned at the moment.