### PR TITLE
Deprecate bytes startswith and endswith

### DIFF
--- a/axiom/attributes.py
+++ b/axiom/attributes.py
@@ -10,7 +10,9 @@ hotfix.require('twisted', 'filepath_copyTo')
 from zope.interface import implements
 
 from twisted.python import filepath
+from twisted.python.deprecate import deprecated
 from twisted.python.components import registerAdapter
+from twisted.python.versions import Version
 
 from epsilon.extime import Time
 
@@ -915,10 +917,23 @@ class bytes(SQLAttribute):
             raise ConstraintError(self, "str or other byte buffer", pyval)
         return buffer(pyval)
 
+
     def outfilter(self, dbval, oself):
         if dbval is None:
             return None
         return str(dbval)
+
+
+    @deprecated(Version("Axiom", 0, 7, 5))
+    def startswith(self, other):
+        return super(SQLAttribute, self).startswith(other)
+
+
+    @deprecated(Version("Axiom", 0, 7, 5))
+    def endswith(self, other):
+        return super(SQLAttribute, self).endswith(other)
+
+
 
 class InvalidPathError(ValueError):
     """

--- a/axiom/attributes.py
+++ b/axiom/attributes.py
@@ -925,6 +925,16 @@ class bytes(SQLAttribute):
 
 
     @deprecated(Version("Axiom", 0, 7, 5))
+    def like(self, *others):
+        return super(SQLAttribute, self).like(*others)
+
+
+    @deprecated(Version("Axiom", 0, 7, 5))
+    def notLike(self, *others):
+        return super(SQLAttribute, self).notLike(*others)
+
+
+    @deprecated(Version("Axiom", 0, 7, 5))
     def startswith(self, other):
         return super(SQLAttribute, self).startswith(other)
 

--- a/axiom/test/test_query.py
+++ b/axiom/test/test_query.py
@@ -1251,17 +1251,17 @@ class WildcardQueries(QueryingTestCase):
 
     def testStartsEndsWith(self):
         self.assertQuery(
-            D.one.startswith('foo'),
-            '(%s LIKE (?))' % (D.one.getColumnName(self.store),),
+            D.four.startswith(u'foo'),
+            '(%s LIKE (?))' % (D.four.getColumnName(self.store),),
             ['foo%'])
         self.assertQuery(
-            D.one.endswith('foo'),
-            '(%s LIKE (?))' % (D.one.getColumnName(self.store),),
+            D.four.endswith(u'foo'),
+            '(%s LIKE (?))' % (D.four.getColumnName(self.store),),
             ['%foo'])
         self.assertEquals(
-            self.query(D, D.one.startswith('d1')), [self.d1])
+            self.query(D, D.four.startswith(u'd1')), [self.d1])
         self.assertEquals(
-            self.query(D, D.one.endswith('3.one')), [self.d3])
+            self.query(D, D.four.endswith(u'3.four')), [self.d3])
 
 
     def testStartsEndsWithColumn(self):

--- a/axiom/test/test_query.py
+++ b/axiom/test/test_query.py
@@ -1264,16 +1264,6 @@ class WildcardQueries(QueryingTestCase):
             self.query(D, D.four.endswith(u'3.four')), [self.d3])
 
 
-    def testStartsEndsWithColumn(self):
-        self.assertQuery(
-            D.one.startswith(D.two),
-            '(%s LIKE (%s || ?))' % (D.one.getColumnName(self.store),
-                                     D.two.getColumnName(self.store)),
-            ['%'])
-        self.assertEquals(
-            self.query(D, D.one.startswith(D.two)), [])
-
-
     def testStartsEndsWithText(self):
         self.assertEquals(
             self.query(D, D.four.startswith(u'd1')),
@@ -1282,20 +1272,6 @@ class WildcardQueries(QueryingTestCase):
             self.query(D, D.four.endswith(u'2.four')),
             [self.d2])
 
-
-    def testOtherTable(self):
-        self.assertQuery(
-            D.one.startswith(A.type),
-            '(%s LIKE (%s || ?))' % (D.one.getColumnName(self.store),
-                                     A.type.getColumnName(self.store)),
-            ['%'])
-
-        C(store=self.store, name=u'd1.')
-        C(store=self.store, name=u'2.one')
-        self.assertEquals(
-            self.query(D, D.one.startswith(C.name)), [self.d1])
-        self.assertEquals(
-            self.query(D, D.one.endswith(C.name)), [self.d2])
 
 
 class UniqueTest(TestCase):

--- a/axiom/test/test_query.py
+++ b/axiom/test/test_query.py
@@ -1780,7 +1780,6 @@ class BytesDeprecatedLikeTests(TestCase):
     Deprecated tests for LIKE queries on L{axiom.attributes.bytes}.
     """
     def test_startsWith(self):
-        s = Store()
         self.assertWarns(
             DeprecationWarning,
             'axiom.attributes.startswith was deprecated in Axiom 0.7.5',
@@ -1789,7 +1788,6 @@ class BytesDeprecatedLikeTests(TestCase):
 
 
     def test_endsWith(self):
-        s = Store()
         self.assertWarns(
             DeprecationWarning,
             'axiom.attributes.endswith was deprecated in Axiom 0.7.5',
@@ -1798,7 +1796,6 @@ class BytesDeprecatedLikeTests(TestCase):
 
 
     def test_like(self):
-        s = Store()
         self.assertWarns(
             DeprecationWarning,
             'axiom.attributes.like was deprecated in Axiom 0.7.5',
@@ -1807,7 +1804,6 @@ class BytesDeprecatedLikeTests(TestCase):
 
 
     def test_notLike(self):
-        s = Store()
         self.assertWarns(
             DeprecationWarning,
             'axiom.attributes.notLike was deprecated in Axiom 0.7.5',

--- a/axiom/test/test_query.py
+++ b/axiom/test/test_query.py
@@ -1218,8 +1218,8 @@ class WildcardQueries(QueryingTestCase):
             D.one.notLike('foobar%'),
             '(%s NOT LIKE (?))' % (D.one.getColumnName(self.store),),
             ['foobar%'])
-        self.assertEquals(self.query(D, D.one.like('d1.one')), [self.d1])
-        self.assertEquals(self.query(D, D.one.notLike('d%.one')), [])
+        self.assertEquals(self.query(D, D.four.like(u'd1.four')), [self.d1])
+        self.assertEquals(self.query(D, D.four.notLike(u'd%.four')), [])
 
     def testOneColumn(self):
         self.assertQuery(
@@ -1230,11 +1230,11 @@ class WildcardQueries(QueryingTestCase):
 
     def testOneColumnAndStrings(self):
         self.assertQuery(
-            D.one.like('%', D.id, '%one'),
-            '(%s LIKE (? || %s || ?))' % (D.one.getColumnName(self.store),
+            D.four.like(u'%', D.id, u'%four'),
+            '(%s LIKE (? || %s || ?))' % (D.four.getColumnName(self.store),
                                           D.id.getColumnName(self.store)),
-            ['%', '%one'])
-        q = self.query(D, D.one.like('%', D.id, '%one'))
+            [u'%', u'%four'])
+        q = self.query(D, D.four.like(u'%', D.id, u'%four'))
         e = [self.d1, self.d2, self.d3]
         self.assertEquals(sorted(q), sorted(e))
 

--- a/axiom/test/test_query.py
+++ b/axiom/test/test_query.py
@@ -1772,3 +1772,44 @@ class PlaceholderTestCase(TestCase):
         expectedSQL = "placeholder_0.oid, placeholder_0.[attr], placeholder_0.[characters], placeholder_0.[other]"
 
         self.assertEquals(query._queryTarget, expectedSQL)
+
+
+
+class BytesDeprecatedLikeTests(TestCase):
+    """
+    Deprecated tests for LIKE queries on L{axiom.attributes.bytes}.
+    """
+    def test_startsWith(self):
+        s = Store()
+        self.assertWarns(
+            DeprecationWarning,
+            'axiom.attributes.startswith was deprecated in Axiom 0.7.5',
+            __file__,
+            lambda: D.one.startswith('string'))
+
+
+    def test_endsWith(self):
+        s = Store()
+        self.assertWarns(
+            DeprecationWarning,
+            'axiom.attributes.endswith was deprecated in Axiom 0.7.5',
+            __file__,
+            lambda: D.one.endswith('string'))
+
+
+    def test_like(self):
+        s = Store()
+        self.assertWarns(
+            DeprecationWarning,
+            'axiom.attributes.like was deprecated in Axiom 0.7.5',
+            __file__,
+            lambda: D.one.like('string'))
+
+
+    def test_notLike(self):
+        s = Store()
+        self.assertWarns(
+            DeprecationWarning,
+            'axiom.attributes.notLike was deprecated in Axiom 0.7.5',
+            __file__,
+            lambda: D.one.notLike('string'))


### PR DESCRIPTION
See issue #60 for why 2 tests where deleted.

Fixes #56.