### PR TITLE
Allow configuring the SQLite journal mode.

### DIFF
--- a/axiom/scripts/axiomatic.py
+++ b/axiom/scripts/axiomatic.py
@@ -123,6 +123,8 @@ class Start(twistd.ServerOptions):
         if not platform.isWindows() and handlePidfile:
             args.extend(["--pidfile", run.child("axiomatic.pid").path])
         args.extend(["axiomatic-start", "--dbdir", store.dbdir.path])
+        if store.journalMode is not None:
+            args.extend(['--journal-mode', store.journalMode.encode('ascii')])
         return args
 
 
@@ -168,6 +170,7 @@ class Options(usage.Options):
 
     optParameters = [
         ('dbdir', 'd', None, 'Path containing axiom database to configure/create'),
+        ('journal-mode', None, None, 'SQLite journal mode to set'),
         ]
 
     optFlags = [
@@ -197,8 +200,12 @@ class Options(usage.Options):
 
     def getStore(self):
         from axiom.store import Store
+        jm = self['journal-mode']
+        if jm is not None:
+            jm = jm.decode('ascii')
         if self.store is None:
-            self.store = Store(self.getStoreDirectory(), debug=self['debug'])
+            self.store = Store(
+                self.getStoreDirectory(), debug=self['debug'], journalMode=jm)
         return self.store
 
 

--- a/axiom/store.py
+++ b/axiom/store.py
@@ -1116,7 +1116,8 @@ class Store(Empowered):
     storeID = STORE_SELF_ID
 
 
-    def __init__(self, dbdir=None, filesdir=None, debug=False, parent=None, idInParent=None):
+    def __init__(self, dbdir=None, filesdir=None, debug=False, parent=None,
+                 idInParent=None, journalMode=None):
         """
         Create a store.
 
@@ -1147,6 +1148,7 @@ class Store(Empowered):
         self.idInParent = idInParent
         self.debug = debug
         self.autocommit = True
+        self.journalMode = journalMode
         self.queryTimes = []
         self.execTimes = []
 
@@ -1373,6 +1375,9 @@ class Store(Empowered):
     def _initdb(self, dbfname):
         self.connection = Connection.fromDatabaseName(dbfname)
         self.cursor = self.connection.cursor()
+        if self.journalMode is not None:
+            self.querySchemaSQL(
+                'PRAGMA *DATABASE*.journal_mode = {}'.format(self.journalMode))
 
 
     def __repr__(self):

--- a/axiom/substore.py
+++ b/axiom/substore.py
@@ -47,17 +47,19 @@ class SubStore(Item):
         del self.substore
 
 
-    def open(self, debug=False):
+    def open(self, debug=None):
         if hasattr(self, 'substore'):
             return self.substore
         else:
-            s = self.substore = self.createStore(debug)
+            if debug is None:
+                debug = self.store.debug
+            s = self.substore = self.createStore(debug, self.store.journalMode)
             s._openSubStore = self # don't fall out of cache as long as the
                                    # store is alive!
             return s
 
 
-    def createStore(self, debug):
+    def createStore(self, debug, journalMode=None):
         """
         Create the actual Store this Substore represents.
         """
@@ -72,12 +74,14 @@ class SubStore(Item):
             return Store(parent=self.store,
                          filesdir=filesdir,
                          idInParent=self.storeID,
-                         debug=debug)
+                         debug=debug,
+                         journalMode=journalMode)
         else:
             return Store(self.storepath.path,
                          parent=self.store,
                          idInParent=self.storeID,
-                         debug=debug)
+                         debug=debug,
+                         journalMode=journalMode)
 
 
     def __conform__(self, interface):

--- a/axiom/test/test_axiomatic.py
+++ b/axiom/test/test_axiomatic.py
@@ -74,6 +74,7 @@ class StartTests(TestCase):
     """
     Test the axiomatic start sub-command.
     """
+    maxDiff = None
     def setUp(self):
         """
         Work around Twisted #3178 by tricking trial into thinking something
@@ -95,10 +96,10 @@ class StartTests(TestCase):
         L{Start.getArguments} adds a I{--pidfile} argument if one is not
         present and a I{--logfile} argument if one is not present and
         daemonization is enabled and adds a I{--dbdir} argument pointing at the
-        store it is passed.
+        store it is passed. It also adds I{--journal-mode} if this is passed.
         """
         dbdir = FilePath(self.mktemp())
-        store = Store(dbdir)
+        store = Store(dbdir, journalMode=u'WAL')
         run = self._getRunDir(dbdir)
         logs = self._getLogDir(dbdir)
         start = axiomatic.Start()
@@ -111,7 +112,8 @@ class StartTests(TestCase):
             pidfileArg = []
         else:
             pidfileArg = ["--pidfile", run.child("axiomatic.pid").path]
-        restArg = ["axiomatic-start", "--dbdir", dbdir.path]
+        restArg = [
+            "axiomatic-start", "--dbdir", dbdir.path, "--journal-mode", "WAL"]
 
         self.assertEqual(
             start.getArguments(store, []),
@@ -221,7 +223,8 @@ class StartTests(TestCase):
         """
         dbdir = self.mktemp()
         store = Store(dbdir)
-        service = AxiomaticStart.makeService({'dbdir': dbdir, 'debug': False})
+        service = AxiomaticStart.makeService(
+            {'dbdir': dbdir, 'debug': False, 'journal-mode': None})
         self.assertEqual(store.query(SystemVersion).count(), 0)
         service.startService()
         self.assertEqual(store.query(SystemVersion).count(), 1)
@@ -230,16 +233,19 @@ class StartTests(TestCase):
 
     def test_axiomOptions(self):
         """
-        L{AxiomaticStart.options} takes database location and debug setting
-        parameters.
+        L{AxiomaticStart.options} takes database location, debug, and
+        journal mode setting parameters.
         """
         options = AxiomaticStart.options()
         options.parseOptions([])
         self.assertEqual(options['dbdir'], None)
         self.assertFalse(options['debug'])
-        options.parseOptions(["--dbdir", "foo", "--debug"])
+        self.assertEqual(options['journal-mode'], None)
+        options.parseOptions(
+            ["--dbdir", "foo", "--debug", "--journal-mode", "WAL"])
         self.assertEqual(options['dbdir'], 'foo')
         self.assertTrue(options['debug'])
+        self.assertEqual(options['journal-mode'], 'WAL')
 
 
     def test_makeService(self):
@@ -254,7 +260,8 @@ class StartTests(TestCase):
         store.powerUp(recorder, IService)
         store.close()
 
-        service = AxiomaticStart.makeService({"dbdir": dbdir, "debug": False})
+        service = AxiomaticStart.makeService(
+            {'dbdir': dbdir, 'debug': False, 'journal-mode': None})
         service.startService()
         service.stopService()
 
@@ -489,3 +496,19 @@ class TestMisc(TestCase):
 
         self.failUnless(IAxiomaticCommand.providedBy(_TestSubClass), 'IAxiomaticCommand not provided')
         self.failUnless(IPlugin.providedBy(_TestSubClass), 'IPlugin not provided')
+
+
+
+class AxiomaticTests(TestCase):
+    """
+    Test things relating to the I{axiomatic} command itself.
+    """
+    def test_journalMode(self):
+        """
+        I{axiomatic} sets the journal mode of the store according to
+        I{--journal-mode}.
+        """
+        options = axiomatic.Options()
+        options['dbdir'] = self.mktemp()
+        options['journal-mode'] = 'WAL'
+        self.assertEqual(options.getStore().journalMode, u'WAL')

--- a/axiom/test/test_substore.py
+++ b/axiom/test/test_substore.py
@@ -142,6 +142,18 @@ class SubStoreTest(unittest.TestCase):
             e.args[0], "Received 'notasequence' instead of a sequence")
 
 
+    def test_inheritParentConfiguration(self):
+        """
+        Substores use the debug and journal configuration of the parent store.
+        """
+        filesdir = filepath.FilePath(self.mktemp())
+        s = Store(filesdir=filesdir, debug=True, journalMode=u'MEMORY')
+        ss = SubStore.createNew(s, ['account', 'bob@divmod.com'])
+        s2 = ss.open()
+        self.assertEqual(s2.debug, True)
+        self.assertEqual(s2.journalMode, u'MEMORY')
+
+
 
 class SubStoreStartupSemantics(unittest.TestCase):
     """

--- a/axiom/test/test_xatop.py
+++ b/axiom/test/test_xatop.py
@@ -434,6 +434,30 @@ s.close()
         self.assertTrue(cursor.closed, 'Cursor should be closed')
 
 
+    def test_journalMode(self):
+        """
+        Passing a journalling mode sets that mode on open.
+        """
+        dbdir = filepath.FilePath(self.mktemp())
+        s = store.Store(dbdir, journalMode=u'MEMORY')
+        self.assertEquals(
+            s.querySchemaSQL('PRAGMA *DATABASE*.journal_mode'),
+            [(u'memory',)])
+
+
+    def test_journalModeNone(self):
+        """
+        Passing a journalling mode of C{None} sets no mode.
+        """
+        dbdir = filepath.FilePath(self.mktemp())
+        s = store.Store(dbdir, journalMode=u'WAL')
+        s.close()
+        s = store.Store(dbdir, journalMode=None)
+        self.assertEquals(
+            s.querySchemaSQL('PRAGMA *DATABASE*.journal_mode'),
+            [(u'wal',)])
+
+
 
 class FailurePathTests(unittest.TestCase):
 

--- a/twisted/plugins/axiom_plugins.py
+++ b/twisted/plugins/axiom_plugins.py
@@ -39,7 +39,9 @@ class AxiomaticStart(object):
 
     class options(Options):
         optParameters = [
-            ('dbdir', 'd', None, 'Path containing Axiom database to start')]
+            ('dbdir', 'd', None, 'Path containing Axiom database to start'),
+            ('journal-mode', None, None, 'SQLite journal mode to set'),
+            ]
 
         optFlags = [('debug', 'b', 'Enable Axiom-level debug logging')]
 
@@ -50,7 +52,10 @@ class AxiomaticStart(object):
         configuration.
         """
         from axiom.store import Store
-        store = Store(options['dbdir'], debug=options['debug'])
+        jm = options['journal-mode']
+        if jm is not None:
+            jm = jm.decode('ascii')
+        store = Store(options['dbdir'], debug=options['debug'], journalMode=jm)
         service = IService(store)
         _CheckSystemVersion(store).setServiceParent(service)
         return service


### PR DESCRIPTION
Closes #76.

My plan is to release this with the default of None, then change the default to
WAL in the next release, thus allowing a graceful transition for anyone that
needs to keep a different mode in use.