### PR TITLE
Lockdown Twisted supported versions for Python 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, pypy2]
+        python: [pypy2]
         twisted: [twtrunk, twlatest, twlowest]
+        include: # 2.7 only supports up to twpy27 not trunk or latest anymore
+          - python: 2.7
+            twisted: twpy27
+          - python: 2.7
+            twisted: twlowest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [pypy2]
-        twisted: [twtrunk, twlatest, twlowest]
-        include: # 2.7 only supports up to twpy27 not trunk or latest anymore
-          - python: 2.7
-            twisted: twpy27
-          - python: 2.7
-            twisted: twlowest
+        python: [2.7, pypy2]
+        twisted: [twpy27, twlowest]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,pypy}-{twtrunk,twlatest,twlowest
+envlist = {py27,pypy}-{twtrunk,twlatest,twlowest,twpy27}
 isolated_build = True
 
 [testenv]
@@ -8,6 +8,7 @@ deps =
     twlatest: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
     twlowest: Twisted==16.0
+    twpy27: Twisted==20.3 # https://labs.twistedmatrix.com/2020/03/twisted-drops-python-27-support.html
     coverage
 commands =
     coverage run --source {envsitepackagesdir}/axiom/ --branch \


### PR DESCRIPTION
Twisted trunk no longer supports Python 2, and once a >20.3.0 version comes out, [neither will latest](https://labs.twistedmatrix.com/2020/03/twisted-drops-python-27-support.html). This PR locks down the Python 2.7 and pypy2 CI testing to just lowest and 20.3.0.

Note that this doesn't remove the Tox latest/trunk environments, as those can be re-enabled once  #119 gets merged for Python 3 support